### PR TITLE
Add uglifyjs dependency..

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "bugs": {
     "url": "https://github.com/jillix/piklor.js/issues"
   },
-  "homepage": "https://github.com/jillix/piklor.js"
+  "homepage": "https://github.com/jillix/piklor.js",
+  "devDependencies": {
+    "uglifyjs": "^2.4.10"
+  }
 }


### PR DESCRIPTION
.. so that `npm run min` doesn't fail if you don't have it globally
